### PR TITLE
chore: item border 지정

### DIFF
--- a/src/Components/item/Item.js
+++ b/src/Components/item/Item.js
@@ -15,6 +15,7 @@ export default function Item({
   likeCount,
   width,
   height,
+  borderRad,
 }) {
   const { isClicked, counter, handleHeartClick } = useItemLogic({
     itemId,
@@ -39,7 +40,7 @@ export default function Item({
   };
 
   return (
-    <ItemDiv className="borderRad" width={width}>
+    <ItemDiv  width={width} borderRad ={borderRad}>
       <ItemImg src={itemImage} alt={name} width={width} height={height} />
       <AiOutlineShopping
         className="feedLayerDiv textShadow"
@@ -82,6 +83,7 @@ export default function Item({
 }
 const ItemDiv = styled.div`
   width: ${({ width }) => width || "20rem"};
+  border-radius : ${({borderRad}) => borderRad || '1.5rem'};
   background-color: ${({ theme }) => theme.colors.lightGray};
 
   overflow: hidden;

--- a/src/pages/ranking/Ranking.js
+++ b/src/pages/ranking/Ranking.js
@@ -109,6 +109,7 @@ export default function Ranking({
               likeCount={item.likeCount}
               width={"15rem"}
               height={"15rem"}
+              borderRad ={"0.5rem"}
             />
           ))}
         </div>


### PR DESCRIPTION
### chore
border-radius 지정할 수 있게 바꿨습니다. (기본 1.5 rem)

```javascript
 <Item
              key={item.id}
              itemId={item.id}
              brand={item.brand}
              name={item.name}
              price={item.price}
              itemImage={item.itemUrl}
              shoppingLink={item.shoppingLink}
              likeCount={item.likeCount}
              width={"15rem"}
              height={"15rem"}
              borderRad ={"0.5rem"}
            />
``` 