### PR TITLE
refact/ranking : 랭킹 페이지 디자인 수정

### DIFF
--- a/src/pages/ranking/Ranking.js
+++ b/src/pages/ranking/Ranking.js
@@ -67,7 +67,8 @@ export default function Ranking({
             <ul className="mainUl">
               <li>
                 <a
-                  className="blackText mainUl mainNav boldContent"
+                  className="blackText mainUl mainNav"
+                  style={{ fontWeight: rankingType === 0 ? "bold" : "normal" }}
                   href="#"
                   onClick={() => handleRankingTypeChange(0)}
                 >
@@ -76,7 +77,8 @@ export default function Ranking({
               </li>
               <li className="ml05">
                 <a
-                  className="blackText mainUl mainNav boldContent"
+                  className="blackText mainUl mainNav"
+                  style={{ fontWeight: rankingType === 1 ? "bold" : "normal" }}
                   href="#"
                   onClick={() => handleRankingTypeChange(1)}
                 >
@@ -85,32 +87,51 @@ export default function Ranking({
               </li>
               <li className="ml05">
                 <a
-                  className="blackText mainUl mainNav boldContent"
+                  className="blackText mainUl mainNav"
+                  style={{ fontWeight: rankingType === 2 ? "bold" : "normal" }}
                   href="#"
                   onClick={() => handleRankingTypeChange(2)}
                 >
                   주간
                 </a>
               </li>
+
             </ul>
           </ul>
         </div>
 
         <div style={{ display: "flex", flexWrap: "wrap" }}>
-          {items.map((item) => (
-            <Item
-              key={item.id}
-              itemId={item.id}
-              brand={item.brand}
-              name={item.name}
-              price={item.price}
-              itemImage={item.itemUrl}
-              shoppingLink={item.shoppingLink}
-              likeCount={item.likeCount}
-              width={"15rem"}
-              height={"15rem"}
-              borderRad ={"0.5rem"}
-            />
+          {items.map((item, index) => (
+            <div key={item.id} style={{ position: "relative" }}>
+              {/* 랭킹 순위 표시 */}
+              <div
+                style={{
+                  position: "absolute",
+                  top: "1rem",
+                  left: "1rem",
+                  backgroundColor: "rgba(0, 0, 0, 0.7)",
+                  color: "white",
+                  padding: "0.3rem",
+                  borderRadius: "0.3rem",
+                  zIndex: "9999",
+                  width: "1.5rem",
+                }}
+              >
+                {index + 1}
+              </div>
+              <Item
+                itemId={item.id}
+                brand={item.brand}
+                name={item.name}
+                price={item.price}
+                itemImage={item.itemUrl}
+                shoppingLink={item.shoppingLink}
+                likeCount={item.likeCount}
+                width={"15rem"}
+                height={"15rem"}
+                borderRad={"0.5rem"}
+              />
+            </div>
           ))}
         </div>
       </div>


### PR DESCRIPTION
1. 랭킹 각 아이템마다 순위 표현
![image](https://github.com/user-attachments/assets/bd526849-eccc-4c32-8af7-f5d54ebc86fa)


2. 실시간, 일간, 주간 분류 
 평상시에는 normal, 선택시에 bold 되도록 수정

